### PR TITLE
Close #1,#2,#7: Added v2 protocol flag handling

### DIFF
--- a/ble/moonboard_BLE_service.py
+++ b/ble/moonboard_BLE_service.py
@@ -103,11 +103,12 @@ class MoonApplication(dbus.service.Object):
 
     def process_rx(self,ba):
         new_problem_string= self.unstuffer.process_bytes(ba)
-        mini = self.unstuffer.mini
+        flags = self.unstuffer.flags
 
         if new_problem_string is not None:
-            problem= decode_problem_string(new_problem_string, mini)
+            problem= decode_problem_string(new_problem_string, flags)
             self.new_problem(json.dumps(problem))
+            self.unstuffer.flags = ''
             start_adv(self.logger)
 
     @dbus.service.signal(dbus_interface="com.moonboard",


### PR DESCRIPTION
Added v2 protocol handling. This includes and extra packet before the description of the problem:
```
start adv
< HCI Command: ogf 0x08, ocf 0x000a, plen 1
  01 
> HCI Event: 0x0e plen 4
  01 0A 20 0C 
New data 302c4531333123
incoming bytes:~M*
MINI
New data 7e4d2a
incoming bytes:l#S53,S19,P75,P15,E8
START
New data 6c235335332c5331392c5037352c5031352c4538
incoming bytes:3#
STOP
Signal new problem: {"START": ["E6", "B5"], "MOVES": ["G4", "B9"], "TOP": ["G12"], "FLAGS": ["M"]}
```
Added additional FLAGS to the problem description to allow both Mini-moonboard handling and above/below lighting configurations.